### PR TITLE
Update from upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,11 @@ ARGS:
 git clone https://github.com/paritytech/cargo-remote
 cargo install --path cargo-remote/ -f
 ```
+
+### MacOS Problems
+It was reported that the `rsync` version shipped with MacOS doesn't support the progress flag and thus fails when
+`cargo-remote` tries to use it. You can install a newer version by running
+```bash
+brew install rsync
+```
+See also [#10](https://github.com/sgeisler/cargo-remote/issues/10).

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use toml::Value;
 
 use log::{error, info, warn};
 
+const PROGRESS_FLAG: &str = "--info=progress2";
+
 #[derive(StructOpt, Debug)]
 #[structopt(name = "cargo-remote", bin_name = "cargo")]
 enum Opts {


### PR DESCRIPTION
Updates README with a notice for Mac users, 
adds flag for `rsync`