### PR TITLE
Fix build path to allow transfers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Cargo subcommand to build rust projects remotely"
 keywords = ["remote", "build"]
 categories = ["command-line-utilities", "development-tools::build-utils", "development-tools::cargo-plugins"]
 maintenance = { status = "experimental" }
-version = "0.1.2"
+version = "0.1.99"
 authors = ["Sebastian Geisler <sgeisler@wh2.tu-dresden.de>"]
 license = "MIT"
 repository = "https://github.com/sgeisler/cargo-remote"

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,7 +227,7 @@ fn main() {
             .arg("--delete")
             .arg("--compress")
             .arg("--info=progress2")
-            .arg(format!("{}:{}/target/{}", build_server, build_path, file_name))
+            .arg(format!("{}:{}target/{}", build_server, build_path, file_name))
             .arg(format!("{}/target/{}", project_dir.to_string_lossy(), file_name))
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ fn main() {
             exit(-3);
         });
 
-    let build_path = format!("~/remote-builds/{:?}/", project_name);
+    let build_path = format!("~/remote-builds/{}/", project_name);
 
     info!("Transferring sources to build server.");
     // transfer project to build server

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn main() {
         .arg("-a".to_owned())
         .arg("--delete")
         .arg("--compress")
-        .arg("--info=progress2")
+        .arg(PROGRESS_FLAG)
         .arg("--exclude")
         .arg("target");
 
@@ -226,7 +226,7 @@ fn main() {
             .arg("-a")
             .arg("--delete")
             .arg("--compress")
-            .arg("--info=progress2")
+            .arg(PROGRESS_FLAG)
             .arg(format!("{}:{}target/{}", build_server, build_path, file_name))
             .arg(format!("{}/target/{}", project_dir.to_string_lossy(), file_name))
             .stdout(Stdio::inherit())
@@ -248,7 +248,7 @@ fn main() {
             .arg("-a")
             .arg("--delete")
             .arg("--compress")
-            .arg("--info=progress2")
+            .arg(PROGRESS_FLAG)
             .arg(format!("{}:{}/Cargo.lock", build_server, build_path))
             .arg(format!("{}/Cargo.lock", project_dir.to_string_lossy()))
             .stdout(Stdio::inherit())

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,10 @@ fn config_from_file(config_path: &Path) -> Option<Value> {
 }
 
 fn main() {
-    simple_logger::init().unwrap();
+    simple_logger::SimpleLogger
+        ::from_env()
+        .init()
+        .unwrap();
 
     let Opts::Remote {
         remote,


### PR DESCRIPTION
Currently the path looks like this:
```
 "~/remote-builds/\"substrate\"/"
```
it doesn't break regular builds (somehow), but `rsync`ing the artifacts back doesn't like it.