### PR TITLE
Always use `/bin/bash` when running commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -196,7 +196,7 @@ fn main() {
     info!("Environment profile: {:?}", env);
     info!("Build path: {:?}", build_path);
     let build_command = format!(
-        "source {}; rustup default {}; cd {}; {} cargo {} {}",
+        "/bin/bash -c 'source {}; rustup default {}; cd {}; {} cargo {} {}'",
         env,
         rustup_default,
         build_path,


### PR DESCRIPTION
I have my shell on the build server to use `fish` because I use it manually fairly frequently and I find it more convenient than `bash` or `zsh`. However, because it's not POSIX compatible, some commands fail. This PR makes the build server always use bash for running commands, eliminating this problem.