### PR TITLE
pretty error printing for cargo metadata errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -130,11 +130,11 @@ fn main() {
     let project_metadata = match metadata_cmd.exec() {
         Ok(m) => m,
         Err(cargo_metadata::Error::CargoMetadata { stderr }) => {
-            eprintln!("Cargo Metadata Execution Error:\n{}", stderr);
+            error!("Cargo Metadata execution failed:\n{}", stderr);
             exit(1)
         },
         Err(e) => {
-            eprintln!("Cargo Metadata Error:\n{:?}", e);
+            error!("Cargo Metadata failed:\n{:?}", e);
             exit(1)
         },
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,17 @@ fn main() {
     let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
     metadata_cmd.manifest_path(manifest_path).no_deps();
 
-    let project_metadata = metadata_cmd.exec().unwrap();
+    let project_metadata = match metadata_cmd.exec() {
+        Ok(m) => m,
+        Err(cargo_metadata::Error::CargoMetadata { stderr }) => {
+            eprintln!("Cargo Metadata Execution Error:\n{}", stderr);
+            exit(1)
+        },
+        Err(e) => {
+            eprintln!("Cargo Metadata Error:\n{:?}", e);
+            exit(1)
+        },
+    };
     let project_dir = project_metadata.workspace_root;
     debug!("Project dir: {:?}", project_dir);
     let mut manifest_path = project_dir.clone();


### PR DESCRIPTION
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: CargoMetadata { stderr: "error: failed to load manifest for workspace member `/home/alexander/dev/parity/substrate/bin/node-template/node`\n\nCaused by:\n  failed to load manifest for dependency `node-template-runtime`\n\nCaused by:\n  failed to load manifest for dependency `construct-extrinsic`\n\nCaused by:\n  failed to parse manifest at `/home/alexander/dev/parity/substrate/bin/node-template/primitives/construct-extrinsic/Cargo.toml`\n\nCaused by:\n  feature `std` includes `frame-support/std`, but `frame-support` is not a dependency\n" }', src/main.rs:130:48
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
becomes
```
Cargo Metadata Execution Error:
error: failed to load manifest for workspace member `/home/alexander/dev/parity/substrate/bin/node-template/node`

Caused by:
  failed to load manifest for dependency `node-template-runtime`

Caused by:
  failed to load manifest for dependency `construct-extrinsic`

Caused by:
  failed to parse manifest at `/home/alexander/dev/parity/substrate/bin/node-template/primitives/construct-extrinsic/Cargo.toml`

Caused by:
  feature `std` includes `frame-support/std`, but `frame-support` is not a dependency
```