### PR TITLE
Remove `SimpleLogger` deprecated call

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn config_from_file(config_path: &PathBuf) -> Option<Value> {
 }
 
 fn main() {
-    simple_logger::SimpleLogger::from_env().init().unwrap();
+    simple_logger::SimpleLogger::new().env().init().unwrap();
 
     let Opts::Remote {
         remote,


### PR DESCRIPTION
Removes deprecation warning

```
warning: use of deprecated associated function `simple_logger::SimpleLogger::from_env`: Use [`env`](#method.env) instead. Will be removed in version 2.0.0.
```