### PR TITLE
Restore previous log level

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,11 @@ fn config_from_file(config_path: &PathBuf) -> Option<Value> {
 }
 
 fn main() {
-    simple_logger::SimpleLogger::new().env().init().unwrap();
+    simple_logger::SimpleLogger::new()
+        .env()
+        .with_level(log::LevelFilter::Error)
+        .init()
+        .unwrap();
 
     let Opts::Remote {
         remote,

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,8 +113,8 @@ fn config_from_file(config_path: &PathBuf) -> Option<Value> {
 
 fn main() {
     simple_logger::SimpleLogger::new()
-        .env()
         .with_level(log::LevelFilter::Error)
+        .env()
         .init()
         .unwrap();
 


### PR DESCRIPTION
`from_env` method was using `Error` log level by default