### PR TITLE
Relax rsync transfer flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -239,12 +239,9 @@ fn main() {
         debug!("Transferring artifacts back to client.");
         let file_name = file_name.unwrap_or_else(String::new);
         Command::new("rsync")
-            .arg(if std::env::consts::OS == "macos" {
-                "-vrltogD"
-            } else {
-                "-a"
-            })
-            .arg("-q")
+            .arg("--links")
+            .arg("--recursive")
+            .arg("--quiet")
             .arg("--delete")
             .arg("--compress")
             .arg(PROGRESS_FLAG)
@@ -269,12 +266,9 @@ fn main() {
     if !no_copy_lock {
         debug!("Transferring Cargo.lock file back to client.");
         Command::new("rsync")
-            .arg(if std::env::consts::OS == "macos" {
-                "-vrltogD"
-            } else {
-                "-a"
-            })
-            .arg("-q")
+            .arg("--links")
+            .arg("--recursive")
+            .arg("--quiet")
             .arg("--delete")
             .arg("--compress")
             .arg(PROGRESS_FLAG)
@@ -305,12 +299,9 @@ pub fn copy_to_remote(
 ) -> Result<std::process::Output, std::io::Error> {
     let mut rsync_to = Command::new("rsync");
     rsync_to
-        .arg(if std::env::consts::OS == "macos" {
-            "-vrltogD"
-        } else {
-            "-a"
-        })
-        .arg("-q")
+        .arg("--links")
+        .arg("--recursive")
+        .arg("--quiet")
         .arg("--delete")
         .arg("--compress")
         .arg(PROGRESS_FLAG)


### PR DESCRIPTION
Currently we are not really requiring all the flags implicitly set by `--archive` flag.

 `--archive` (`-a`) is a shortcut for `rlptgoD`

Where:
- `r`: recursive
- `l`: copy symlinks
- `p`: preserve permissions
- `t`: preserve mod times
- `g`: preserve group
- `o`: preserve owner
- `D`: transfer devices files (e.g. block devices)


Furthermore some of them may cause some warnings when are not supported (e.g. see the current special handling of `perms` on `macos`).

Special handling for `perms` is not only required for filesystems used by macos, but also on others available for Linux systems, e.g. when using `btrfs`.

The only options that we (may) really require are just: `r` and `l`.

Additionally, we are going to pass all required options explicitly and with "long" form for clarity.
