### PR TITLE
rsync: preserve times

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -305,6 +305,7 @@ pub fn copy_to_remote(
     rsync_to
         .arg("--links")
         .arg("--recursive")
+        .arg("--times")
         .arg("--quiet")
         .arg("--delete")
         .arg("--compress")


### PR DESCRIPTION
The `--times` option allows us to exclude files that have not been modified from syncing, thus preventing `cargo` from rebuilding unchanged crates.