### PR TITLE
Fix warning: remove unnecessary .clone()

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
           override: true
 
       - name: Cache Dependencies & Build Outputs
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo/registry

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -114,11 +114,7 @@ fn extract_patched_crates_and_adjust_toml<F: Fn(PathBuf) -> Result<PathBuf, Stri
     for inline_crate_table in patched_paths {
         // We only act if there is a path given for a crate
         if let Some(path) = inline_crate_table.get("path") {
-            let path = PathBuf::from(
-                path.as_str()
-                    .ok_or("Unable to get path from toml Value")?
-                    .clone(),
-            );
+            let path = PathBuf::from(path.as_str().ok_or("Unable to get path from toml Value")?);
 
             // Check if the current crate is located in a subfolder of a workspace we
             // already know.


### PR DESCRIPTION
Fix the following warning in `patches.rs`:
```
warning: call to `.clone()` on a reference in this situation does nothing
   --> src/patches.rs:119:66
    |
119 |                       .ok_or("Unable to get path from toml Value")?
    |  __________________________________________________________________^
120 | |                     .clone(),
    | |____________________________^ help: remove this redundant call
    |
    = note: the type `str` does not implement `Clone`, so calling `clone` on `&str` copies the reference, which does not do anything and can be removed
    = note: `#[warn(noop_method_call)]` on by default
```

By removing the ⁠.clone(), the code becomes more efficient as it avoids an unnecessary string allocation and copy. ⁠